### PR TITLE
remove old ifconfig

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -3535,8 +3535,9 @@ function hdinfo() {
 # returns 0 if we are auto negotiated and 1 if not
 function isNegotiated() {
 # search for first NIC which has an IP
-for i in $(ifconfig -a | grep eth | cut -d " " -f 1); do
-  if [ -n "$(ip a show $i | grep "inet [1-9]")" ]; then
+#for i in $(ifconfig -a | grep eth | cut -d " " -f 1); do
+  for interface in $(find /sys/class/net/* -type l -name 'eth*' -printf '%f\n'); do
+    if [ -n "$(ip a show $i | grep "inet [1-9]")" ]; then
     #check if we got autonegotiated
     if [ -n "$(mii-tool 2>/dev/null | grep "negotiated")" ]; then
       return 0

--- a/installimage
+++ b/installimage
@@ -61,7 +61,7 @@ rm -rf "$FOLD" >> /dev/null 2>&1
 mkdir -p "$FOLD/nfs" >> /dev/null 2>&1
 mkdir -p "$FOLD/hdd" >> /dev/null 2>&1
 cd "$FOLD"
-myip=$(ifconfig eth0 | grep "inet addr" | cut -d: -f2 | cut -d ' ' -f1)
+myip=$(ifdata -pa eth0)
 debug "# starting installimage on  [ $myip ]"
 
 


### PR DESCRIPTION
this PR removes two calls to ifconfig, this is deprecated and on default not available on arch (which is our new preferred OS for running the installimage).

There are four calls to ifconfig in a legacy functions that nobody calls anymore, we could remove that in another PR (this is maybe something for your cleanup branch @foxxx0?)