### PR TITLE
remove old ifconfig

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -3535,29 +3535,27 @@ function isNegotiated() {
   # search for first NIC which has an IP
   for interface in $(find /sys/class/net/* -type l -name 'eth*' -printf '%f\n'); do
     if [ -n "$(ip a show $i | grep "inet [1-9]")" ]; then
-    #check if we got autonegotiated
-    if [ -n "$(mii-tool 2>/dev/null | grep "negotiated")" ]; then
-      return 0
-    else
-      return 1
+      #check if we got autonegotiated
+      if [ -n "$(mii-tool 2>/dev/null | grep "negotiated")" ]; then
+        return 0
+      else
+        return 1
+      fi
     fi
-  fi
-done
+  done
 }
 
 # function to check if we are in a kvm-qemu vServer environment
 # returns 0 if we are in a vServer env otherwise 1
 function isVServer() {
-#  local model="$(cat /proc/cpuinfo | grep "^model name" | cut -d ":" -f2 | tr -d ' ')"
-#  if [ -n "$(echo "$model" | grep -i "QEMUVirtualCPU")" ] || [ -n "$(echo "$model" | grep -i "PentiumII(Klamath)")" ]; then
-   case "$SYSTYPE" in
+  case "$SYSTYPE" in
     vServer|Bochs|Xen|KVM|VirtualBox|'VMware,Inc.')
       debug "# Systype: $SYSTYPE"
       return 0;;
     *) 
       debug "# Systype: $SYSTYPE"
       case "$SYSMFC" in
-      	QEMU)
+        QEMU)
           debug "# Manufacturer: $SYSMFC"
           return 0;;
         *)
@@ -3565,7 +3563,7 @@ function isVServer() {
           return 1;;
       esac
       return 1;;
-    esac
+  esac
 }
 
 # function to check if we have to use GPT or MS-DOS partition tables

--- a/functions.sh
+++ b/functions.sh
@@ -3535,8 +3535,9 @@ function hdinfo() {
 # returns 0 if we are auto negotiated and 1 if not
 function isNegotiated() {
 # search for first NIC which has an IP
-for i in $(ifconfig -a | grep eth | cut -d " " -f 1); do
-  if [ -n "$(ip a show $i | grep "inet [1-9]")" ]; then
+#for i in $(ifconfig -a | grep eth | cut -d " " -f 1); do
+  for interface in $(find /sys/class/net/* -type l -name 'eth*' -printf '%f\n'); do
+    if [ -n "$(ip a show $i | grep "inet [1-9]")" ]; then
     #check if we got autonegotiated
     if [ -n "$(mii-tool 2>/dev/null | grep "negotiated")" ]; then
       return 0

--- a/installimage
+++ b/installimage
@@ -61,7 +61,7 @@ rm -rf "$FOLD" >> /dev/null 2>&1
 mkdir -p "$FOLD/nfs" >> /dev/null 2>&1
 mkdir -p "$FOLD/hdd" >> /dev/null 2>&1
 cd "$FOLD"
-myip=$(ifconfig eth0 | grep "inet addr" | cut -d: -f2 | cut -d ' ' -f1)
+myip=$(ifdata -pa eth0)
 debug "# starting installimage on  [ $myip ]"
 
 


### PR DESCRIPTION
this PR removes two calls to ifconfig, this is deprecated and on default not available on arch (which is our new preferred OS for running the installimage).

There are four calls to ifconfig in a legacy functions that nobody calls anymore, we could remove that in another PR (this is maybe something for your cleanup branch @foxxx0?)