### PR TITLE
validate against shellcheck, add missing blacklists

### DIFF
--- a/suse.sh
+++ b/suse.sh
@@ -6,11 +6,14 @@
 # originally written by Florian Wicke and David Mayr
 # (c) 2007-2015, Hetzner Online GmbH
 #
+# changed and extended by Thore Bödecker, 2015-10-05
+# changed and extended by Tim Meusel
+#
 
 
 # setup_network_config "$device" "$HWADDR" "$IPADDR" "$BROADCAST" "$SUBNETMASK" "$GATEWAY" "$NETWORK" "$IP6ADDR" "$IP6PREFLEN" "$IP6GATEWAY"
 setup_network_config() {
-  if [ "$1" -a "$2" ]; then
+  if [ -n "$1" ] && [ -n "$2" ]; then
     # good we have a device and a MAC
 
     SUSEVERSION="$(grep VERSION $FOLD/hdd/etc/SuSE-release | cut -d ' '  -f3 | sed -e 's/\.//')"
@@ -25,48 +28,48 @@ setup_network_config() {
     # Delete network udev rules
 #    rm $FOLD/hdd/etc/udev/rules.d/*-persistent-net.rules 2>&1 | debugoutput
 
-    echo -e "### Hetzner Online GmbH - installimage" > $UDEVFILE
-    echo -e "# device: $1" >> $UDEVFILE
-    echo -e "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", ATTR{address}==\"$2\", KERNEL==\"eth*\", NAME=\"$1\"" >> $UDEVFILE
+    echo "### $COMPANY - installimage" > $UDEVFILE
+    echo "# device: $1" >> $UDEVFILE
+    printf 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="%s", KERNEL=="eth*", NAME="%s"\n' "$2" "$1" >> "$UDEVFILE"
 
     # remove any other existing config files
     for i in `find "$FOLD/hdd/etc/sysconfig/network/" -name "*-eth*"`; do rm -rf "$i" >>/dev/null 2>&1; done
 
     CONFIGFILE="$FOLD/hdd/etc/sysconfig/network/ifcfg-$1"
 
-    echo -e "### Hetzner Online GmbH - installimage" > $CONFIGFILE 2>>$DEBUGFILE
-    echo -e "# device: $1" >> $CONFIGFILE 2>>$DEBUGFILE
-    echo -e "BOOTPROTO='static'" >> $CONFIGFILE 2>>$DEBUGFILE
-    echo -e "MTU=''" >> $CONFIGFILE 2>>$DEBUGFILE
-    echo -e "STARTMODE='auto'" >> $CONFIGFILE 2>>$DEBUGFILE
-    echo -e "UNIQUE=''" >> $CONFIGFILE 2>>$DEBUGFILE
-    echo -e "USERCONTROL='no'" >> $CONFIGFILE 2>>$DEBUGFILE
+    echo "### $COMPANY - installimage" > "$CONFIGFILE"
+    echo "# device: $1" >> "$CONFIGFILE"
+    echo "BOOTPROTO='static'" >> "$CONFIGFILE"
+    echo "MTU=''" >> "$CONFIGFILE"
+    echo "STARTMODE='auto'" >> "$CONFIGFILE"
+    echo "UNIQUE=''" >> "$CONFIGFILE"
+    echo "USERCONTROL='no'" >> "$CONFIGFILE"
 
-    if [ "$1" -a "$2" -a "$3" -a "$4" -a "$5" -a "$6" -a "$7" ]; then
-      echo -e "REMOTE_IPADDR=''" >> $CONFIGFILE 2>>$DEBUGFILE
-      echo -e "BROADCAST='$4'" >> $CONFIGFILE 2>>$DEBUGFILE
-      echo -e "IPADDR='$3'" >> $CONFIGFILE 2>>$DEBUGFILE
-      echo -e "NETMASK='$5'" >> $CONFIGFILE 2>>$DEBUGFILE
-      echo -e "NETWORK='$7'" >> $CONFIGFILE 2>>$DEBUGFILE
+    if [ -n "$1" ] && [ -n "$2" ] && [ -n "$3" ] && [ -n "$4" ] && [ -n "$5" ] && [ -n "$6" ] && [ -n "$7" ]; then
+      echo "REMOTE_IPADDR=''" >> "$CONFIGFILE"
+      echo "BROADCAST='$4'" >> "$CONFIGFILE"
+      echo "IPADDR='$3'" >> "$CONFIGFILE"
+      echo "NETMASK='$5'" >> "$CONFIGFILE"
+      echo "NETWORK='$7'" >> "$CONFIGFILE"
 
-      echo -e "$7 $6 $5 $1" > $ROUTEFILE 2>>$DEBUGFILE
-      echo -e "$6 - 255.255.255.255 $1" >> $ROUTEFILE 2>>$DEBUGFILE
-      echo -e "default $6 - -" >> $ROUTEFILE 2>>$DEBUGFILE
+      echo "$7 $6 $5 $1" > "$ROUTEFILE"
+      echo "$6 - 255.255.255.255 $1" >> "$ROUTEFILE"
+      echo "default $6 - -" >> "$ROUTEFILE"
     fi
 
-    if [ "$8" -a "$9" -a "${10}" ]; then
+    if [ -n "$8" ] && [ -n "$9" ] && [ -n "${10}" ]; then
       debug "setting up ipv6 networking $8/$9 via ${10}"
-      if [ "$3" ]; then
-	# add v6 addr as an alias, if we have a v4 addr
-        echo -e "IPADDR_0='$8/$9'" >> $CONFIGFILE 2>>$DEBUGFILE
+      if [ -n "$3" ]; then
+      # add v6 addr as an alias, if we have a v4 addr
+        echo -e "IPADDR_0='$8/$9'" >> "$CONFIGFILE"
       else
-        echo -e "IPADDR='$8/$9'" >> $CONFIGFILE 2>>$DEBUGFILE
+        echo -e "IPADDR='$8/$9'" >> "$CONFIGFILE"
       fi
-      echo -e "default ${10} - $1" >> $ROUTEFILE 2>>$DEBUGFILE
+      echo -e "default ${10} - $1" >> "$ROUTEFILE"
     fi
 
     if ! isNegotiated && ! isVServer; then
-      echo -e "ETHTOOL_OPTIONS=\"speed 100 duplex full autoneg off\"" >> $CONFIGFILE 2>>$DEBUGFILE
+      echo 'ETHTOOL_OPTIONS="speed 100 duplex full autoneg off"' >> "$CONFIGFILE"
     fi
 
     return 0
@@ -77,17 +80,17 @@ setup_network_config() {
 generate_config_mdadm() {
   if [ "$1" ]; then
     MDADMCONF="/etc/mdadm.conf"
-    echo "DEVICES /dev/[hs]d*" > $FOLD/hdd$MDADMCONF
-    echo "MAILADDR root" >> $FOLD/hdd$MDADMCONF
+    echo "DEVICES /dev/[hs]d*" > "$FOLD/hdd$MDADMCONF"
+    echo "MAILADDR root" >> "$FOLD/hdd$MDADMCONF"
     if [ "$SUSEVERSION" -ge 132 ] ; then
-      echo >> $FOLD/hdd$MDADMCONF
+      echo >> "$FOLD/hdd$MDADMCONF"
     fi
 #    if [ "$SUSEVERSION" = "11.0" -o "$SUSEVERSION" = "11.2" -o "$SUSEVERSION" = "11.3" -o "$SUSEVERSION" = "11.4" -o "$SUSEVERSION" = "12.1"  -o "$SUSEVERSION" = "12.2" ]; then
     if [ "$SUSEVERSION" -ge 110 ]; then
       # Suse 11.2 argues about failing opening of /dev/md/<number>, so do a --examine instead of --details
-      execute_chroot_command "mdadm --examine --scan >> $MDADMCONF"; EXITCODE=$?
+      execute_chroot_command "mdadm --examine --scan >> $MDADMCONF"; declare -i EXITCODE=$?
     else
-      execute_chroot_command "mdadm --detail --scan >> $MDADMCONF"; EXITCODE=$?
+      execute_chroot_command "mdadm --detail --scan >> $MDADMCONF"; declare -i EXITCODE=$?
     fi
     return $EXITCODE
   fi
@@ -95,26 +98,12 @@ generate_config_mdadm() {
 
 # generate_new_ramdisk "NIL"
 generate_new_ramdisk() {
-  if [ "$1" ]; then
+  if [ -n "$1" ]; then
     OUTFILE=`ls -1r $FOLD/hdd/boot/initrd-* |grep -v ".bak$\|.gz$" |awk -F "/" '{print $NF}' |grep -m1 "initrd"`
     VERSION=`echo $OUTFILE |cut -d "-" -f2-`
 
     # opensuse 13.2 uses dracut for generating initrd
-    if [ "$SUSEVERSION" -ge 132 ] ; then
-      DRACUTFILE="$FOLD/hdd/etc/dracut.conf.d/03-hetzner.conf"
-#      echo "add_dracutmodules+=\"mdraid lvm\"" >> $DRACUTFILE
-#      echo "add_drivers+=\"raid1 raid10 raid0 raid456\"" >> $DRACUTFILE
-#      echo "mdadmconf=\"yes\"" >> $DRACUTFILE
-#      echo "lvmconf=\"yes\"" >> $DRACUTFILE
-#      echo "hostonly=\"no\"" >> $DRACUTFILE
-#      echo "early_microcode=\"no\"" >> $DRACUTFILE
-#
-      # dracut fix for auto-assembling raid
-#      local mdraid_rule="$FOLD/hdd/usr/lib/udev/rules.d/64-md-raid-assembly.rules"
-#      local dracut_rulesd="$FOLD/hdd/usr/lib/dracut/rules.d"
-#      mkdir -p $dracut_rulesd
-#      cp $mdraid_rule $dracut_rulesd
-    else
+    if [ "$SUSEVERSION" -lt 132 ] ; then
       KERNELCONF="$FOLD/hdd/etc/sysconfig/kernel"
 
       sed -i "$KERNELCONF" -e 's/INITRD_MODULES=.*/INITRD_MODULES=""/'
@@ -126,10 +115,16 @@ generate_new_ramdisk() {
     fi
 
     local blacklist_conf="$FOLD/hdd/etc/modprobe.d/99-local.conf"
-    echo -e "### Hetzner Online GmbH - installimage" > $blacklist_conf
-    echo -e "### i915 driver blacklisted due to various bugs" >> $blacklist_conf
-    echo -e "### especially in combination with nomodeset" >> $blacklist_conf
-    echo -e "blacklist i915" >> $blacklist_conf
+    echo "### $COMPANY - installimage" > "$blacklist_conf"
+    echo -e "### silence any onboard speaker" >> "$blacklist_conf"
+    echo -e "blacklist pcspkr" >> "$blacklist_conf"
+    echo -e "blacklist snd_pcsp" >> "$blacklist_conf"
+    echo '### i915 driver blacklisted due to various bugs' >> "$blacklist_conf"
+    echo '### especially in combination with nomodeset' >> "$blacklist_conf"
+    echo "blacklist i915" >> "$blacklist_conf"
+    echo -e "### mei driver blacklisted due to serious bugs" >> "$blacklist_conf"
+    echo -e "blacklist mei" >> "$blacklist_conf" >> "$blacklist_conf"
+    echo -e "blacklist mei-me" >> "$blacklist_conf">> "$blacklist_conf"
 
     local dracut_feature=''
     local dracut_modules=''
@@ -151,29 +146,28 @@ generate_new_ramdisk() {
         if [ "$SUSEVERSION" -ge 132 ]; then
           [ -n "$dracut_feature" ] && mkinitcmd="$mkinitcmd -f '$dracut_feature'"
           [ -n "$dracut_modules" ] && mkinitcmd="$mkinitcmd -m '$dracut_modules'"
-          execute_chroot_command "$mkinitcmd"; EXITCODE=$?
+          execute_chroot_command "$mkinitcmd"; declare -i EXITCODE=$?
         else
-          execute_chroot_command "$mkinitcmd"; EXITCODE=$?
+          execute_chroot_command "$mkinitcmd"; declare -i EXITCODE=$?
         fi
       else
-        execute_chroot_command "mkinitrd"; EXITCODE=$?
+        execute_chroot_command "mkinitrd"; declare -i EXITCODE=$?
       fi
     else
-      execute_chroot_command "mkinitrd -t /tmp"; EXITCODE=$?
+      execute_chroot_command "mkinitrd -t /tmp"; declare -i EXITCODE=$?
     fi
-    return $?
+    return "$EXITCODE"
   fi
 }
 
-
 setup_cpufreq() {
-  if [ "$1" ]; then
+  if [ -n "$1" ]; then
      # openSuSE defaults to the ondemand governor, so we don't need to set this at all
      # http://doc.opensuse.org/documentation/html/openSUSE/opensuse-tuning/cha.tuning.power.html
      # check release notes of furture releases carefully, if this has changed!
 
 #    CPUFREQCONF="$FOLD/hdd/etc/init.d/boot.local"
-#    echo -e "### Hetzner Online GmbH - installimage" > $CPUFREQCONF 2>>$DEBUGFILE
+#    echo -e "### $COMPANY - installimage" > $CPUFREQCONF 2>>$DEBUGFILE
 #    echo -e "# cpu frequency scaling" >> $CPUFREQCONF 2>>$DEBUGFILE
 #    echo -e "cpufreq-set -g $1 -r >> /dev/null 2>&1" >> $CPUFREQCONF 2>>$DEBUGFILE
 
@@ -187,9 +181,9 @@ setup_cpufreq() {
 # Generate the GRUB bootloader configuration.
 #
 generate_config_grub() {
-  [ "$1" ] || return
+  [ -n "$1" ] || return
 
-  EXITCODE=0
+  declare -i EXITCODE=0
 
   if [ "$SUSEVERSION" -lt 122 ]; then
     DMAPFILE="$FOLD/hdd/boot/grub/device.map"
@@ -200,42 +194,41 @@ generate_config_grub() {
     # not passed
     DMAPFILE="$FOLD/hdd/boot/grub2/device.map"
   fi
-  [ -f $DMAPFILE ] && rm $DMAPFILE
+  [ -f "$DMAPFILE" ] && rm "$DMAPFILE"
 
-  local i=0
-  for i in $(seq 1 $COUNT_DRIVES) ; do
-    local j="$[$i-1]"
+  for ((i=1; i<="$COUNT_DRIVES"; i++)); do
+    local j="$((i - 1))"
     local disk="$(eval echo "\$DRIVE"$i)"
-    echo "(hd$j) $disk" >> $DMAPFILE
+    echo "(hd$j) $disk" >> "$DMAPFILE"
   done
-  cat $DMAPFILE >> $DEBUGFILE
+  cat "$DMAPFILE" >> "$DEBUGFILE"
 
   if [ "$SUSEVERSION" -lt 122 ]; then
     BFILE="$FOLD/hdd/boot/grub/menu.lst"
 
-    echo "#" > $BFILE 2>> $DEBUGFILE
-    echo "# Hetzner Online GmbH - installimage" >> $BFILE 2>> $DEBUGFILE
-    echo "# GRUB bootloader configuration file" >> $BFILE 2>> $DEBUGFILE
-    echo "#" >> $BFILE 2>> $DEBUGFILE
-    echo >> $BFILE 2>> $DEBUGFILE
+    echo '#' > "$BFILE" 2>> "$DEBUGFILE"
+    echo "# $COMPANY - installimage" >> "$BFILE" 2>> "$DEBUGFILE"
+    echo '# GRUB bootloader configuration file' >> "$BFILE" 2>> "$DEBUGFILE"
+    echo '#' >> "$BFILE" 2>> "$DEBUGFILE"
+    echo >> "$BFILE" 2>> "$DEBUGFILE"
 
-    PARTNUM=`echo "$SYSTEMBOOTDEVICE" | rev | cut -c1`
+    PARTNUM=$(echo "$SYSTEMBOOTDEVICE" | rev | cut -c1)
 
     if [ "$SWRAID" = "0" ]; then
-      PARTNUM="$[$PARTNUM - 1]"
+      PARTNUM="$((PARTNUM - 1))"
     fi
 
-    echo "timeout 5" >> $BFILE 2>> $DEBUGFILE
-    echo "default 0" >> $BFILE 2>> $DEBUGFILE
-    echo >> $BFILE 2>> $DEBUGFILE
-    echo "title Linux (openSUSE)" >> $BFILE 2>> $DEBUGFILE
-    echo "root (hd0,$PARTNUM)" >> $BFILE 2>> $DEBUGFILE
-    echo "kernel /boot/vmlinuz-$1 root=$SYSTEMROOTDEVICE vga=0x317" >> $BFILE 2>> $DEBUGFILE
+    echo 'timeout 5' >> "$BFILE" 2>> "$DEBUGFILE"
+    echo 'default 0' >> "$BFILE" 2>> "$DEBUGFILE"
+    echo >> "$BFILE" 2>> "$DEBUGFILE"
+    echo 'title Linux (openSUSE)' >> "$BFILE" 2>> "$DEBUGFILE"
+    echo "root (hd0,$PARTNUM)" >> "$BFILE" 2>> "$DEBUGFILE"
+    echo "kernel /boot/vmlinuz-$1 root=$SYSTEMROOTDEVICE vga=0x317" >> "$BFILE" 2>> "$DEBUGFILE"
 
     if [ -f "$FOLD/hdd/boot/initrd-$1" ]; then
-      echo "initrd /boot/initrd-$1" >> $BFILE 2>> $DEBUGFILE
+      echo "initrd /boot/initrd-$1" >> "$BFILE" 2>> "$DEBUGFILE"
     fi
-    echo >> $BFILE 2>> $DEBUGFILE
+    echo >> "$BFILE" 2>> "$DEBUGFILE"
 
   else
     local grub_linux_default="nomodeset"
@@ -262,15 +255,15 @@ generate_config_grub() {
 
     # the opensuse mkinitrd uses this file to determine where to write the bootloader...
     GRUBINSTALLDEV_FILE="$FOLD/hdd/etc/default/grub_installdevice"
-    [ -f $GRUBINSTALLDEV_FILE ] && rm $GRUBINSTALLDEV_FILE
-    for i in $(seq 1 $COUNT_DRIVES) ; do
+    [ -f "$GRUBINSTALLDEV_FILE" ] && rm "$GRUBINSTALLDEV_FILE"
+    for ((i=1; i<="$COUNT_DRIVES"; i++)); do
       local disk="$(eval echo "\$DRIVE"$i)"
-      echo "$disk" >> $GRUBINSTALLDEV_FILE
+      echo "$disk" >> "$GRUBINSTALLDEV_FILE"
     done
-    echo "generic_mbr" >> $GRUBINSTALLDEV_FILE
+    echo "generic_mbr" >> "$GRUBINSTALLDEV_FILE"
   fi
 
-  return $EXITCODE
+  return "$EXITCODE"
 }
 
 #
@@ -283,29 +276,27 @@ write_grub() {
   if [ "$SUSEVERSION" -lt 122 ]; then
     execute_chroot_command "rm -rf /etc/lilo.conf"
 
-    local i=0
-
-    for i in $(seq 1 $COUNT_DRIVES) ; do
-      if [ $SWRAID -eq 1 -o $i -eq 1 ] ;  then
+    for ((i=1; i<="$COUNT_DRIVES"; i++)); do
+      if [ "$SWRAID" -eq 1 ] || [ $i -eq 1 ] ;  then
         local disk="$(eval echo "\$DRIVE"$i)"
         execute_chroot_command "echo -e \"device (hd0) $disk\nroot (hd0,$PARTNUM)\nsetup (hd0)\nquit\" | grub --batch >> /dev/null 2>&1"
       fi
     done
   else
     # only install grub2 in mbr of all other drives if we use swraid
-    local i=0
-    for i in $(seq 1 $COUNT_DRIVES) ; do
-      if [ $SWRAID -eq 1 -o $i -eq 1 ] ;  then
+    for ((i=1; i<="$COUNT_DRIVES"; i++)); do
+      if [ "$SWRAID" -eq 1 ] || [ "$i" -eq 1 ] ;  then
         local disk="$(eval echo "\$DRIVE"$i)"
-        execute_chroot_command "grub2-install --no-floppy --recheck $disk 2>&1" EXITCODE=$?
+        execute_chroot_command "grub2-install --no-floppy --recheck $disk 2>&1" declare -i EXITCODE="$?"
       fi
     done
   fi
   uuid_bugfix
 
-  return $?
+  return "$EXITCODE"
 
 }
+
 #
 # os specific functions
 # for purpose of e.g. debian-sys-maint mysql user password in debian/ubuntu LAMP
@@ -313,6 +304,4 @@ write_grub() {
 run_os_specific_functions() {
   return 0
 }
-
-
 

--- a/suse.sh
+++ b/suse.sh
@@ -61,11 +61,11 @@ setup_network_config() {
       debug "setting up ipv6 networking $8/$9 via ${10}"
       if [ -n "$3" ]; then
       # add v6 addr as an alias, if we have a v4 addr
-        echo -e "IPADDR_0='$8/$9'" >> "$CONFIGFILE"
+        echo "IPADDR_0='$8/$9'" >> "$CONFIGFILE"
       else
-        echo -e "IPADDR='$8/$9'" >> "$CONFIGFILE"
+        echo "IPADDR='$8/$9'" >> "$CONFIGFILE"
       fi
-      echo -e "default ${10} - $1" >> "$ROUTEFILE"
+      echo "default ${10} - $1" >> "$ROUTEFILE"
     fi
 
     if ! isNegotiated && ! isVServer; then
@@ -116,15 +116,15 @@ generate_new_ramdisk() {
 
     local blacklist_conf="$FOLD/hdd/etc/modprobe.d/99-local.conf"
     echo "### $COMPANY - installimage" > "$blacklist_conf"
-    echo -e "### silence any onboard speaker" >> "$blacklist_conf"
-    echo -e "blacklist pcspkr" >> "$blacklist_conf"
-    echo -e "blacklist snd_pcsp" >> "$blacklist_conf"
+    echo '### silence any onboard speaker' >> "$blacklist_conf"
+    echo 'blacklist pcspkr' >> "$blacklist_conf"
+    echo 'blacklist snd_pcsp' >> "$blacklist_conf"
     echo '### i915 driver blacklisted due to various bugs' >> "$blacklist_conf"
     echo '### especially in combination with nomodeset' >> "$blacklist_conf"
-    echo "blacklist i915" >> "$blacklist_conf"
-    echo -e "### mei driver blacklisted due to serious bugs" >> "$blacklist_conf"
-    echo -e "blacklist mei" >> "$blacklist_conf" >> "$blacklist_conf"
-    echo -e "blacklist mei-me" >> "$blacklist_conf">> "$blacklist_conf"
+    echo 'blacklist i915' >> "$blacklist_conf"
+    echo '### mei driver blacklisted due to serious bugs' >> "$blacklist_conf"
+    echo 'blacklist mei' >> "$blacklist_conf" >> "$blacklist_conf"
+    echo 'blacklist mei-me' >> "$blacklist_conf">> "$blacklist_conf"
 
     local dracut_feature=''
     local dracut_modules=''
@@ -195,7 +195,7 @@ generate_config_grub() {
     DMAPFILE="$FOLD/hdd/boot/grub2/device.map"
   fi
   [ -f "$DMAPFILE" ] && rm "$DMAPFILE"
-
+  local -i i=0
   for ((i=1; i<="$COUNT_DRIVES"; i++)); do
     local j="$((i - 1))"
     local disk="$(eval echo "\$DRIVE"$i)"


### PR DESCRIPTION
this changes style stuff like:
* quotation
* indentation
* trailing whitespace
* adding comments
* use printf were usefull
* start to use local/ro vars

we also blacklist me + speaker modules, this is a C&P issue, they are
already blocked everywhere else