### PR TITLE
add shellcheck in travis

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build"]
+	path = build
+	url = https://github.com/caarlos0/shell-ci-build.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: bash
+install:
+  - ./build/install.sh
+script:
+  - ./build/build.sh
+notifications:
+  email: false
+  irc:
+    on_success: change
+    on_failure: always
+    channels:
+      - "irc.freenode.org#virtapi"
+sudo: required


### PR DESCRIPTION
this adds https://github.com/caarlos0/shell-ci-build as a submodule and
should enable travis