### PR TITLE
Fix obvious typo. (centos.sh)

### DIFF
--- a/centos.sh
+++ b/centos.sh
@@ -293,14 +293,14 @@ generate_config_grub() {
 write_grub() {
   if [ "$IMG_VERSION" -ge 70 ] ; then
     # only install grub2 in mbr of all other drives if we use swraid
-    for ((i=1; i<="$COUND_DRIVES"; i++)); do
+    for ((i=1; i<="$COUNT_DRIVES"; i++)); do
       if [ "$SWRAID" -eq 1 ] || [ "$i" -eq 1 ] ;  then
         local disk="$(eval echo "\$DRIVE"$i)"
         execute_chroot_command "grub2-install --no-floppy --recheck $disk 2>&1" declare -i EXITCODE=$?
       fi
     done
   else
-    for ((i=1; i<="$COUND_DRIVES"; i++)); do
+    for ((i=1; i<="$COUNT_DRIVES"; i++)); do
       if [ "$SWRAID" -eq 1 ] || [ $i -eq 1 ] ;  then
         local disk="$(eval echo "\$DRIVE"$i)"
         execute_chroot_command "echo -e \"device (hd0) $disk\nroot (hd0,$PARTNUM)\nsetup (hd0)\nquit\" | grub --batch >> /dev/null 2>&1"


### PR DESCRIPTION
the centos.sh was broken.. nowhere in the codebase the variable
COUND_DRIVES is set.