### PR TITLE
Add support for sshkeys via config file

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -804,6 +804,15 @@ if [ -n "$1" ]; then
     C_SHORT="${c_short_custom}"
   fi
 
+  # overwrite SSH key settings from commandline
+  # you can set that also via -K, but configfile is superior
+  local sshkeys_url
+  sshkeys_url=$(grep -m1 -e ^SSHKEYS_URL "${1}" | awk '{print $2}')
+  if [ -n "$sshkeys_url" ]; then
+    export OPT_SSHKEYS_URL="$sshkeys_url"
+    export OPT_USE_SSHKEYS=1
+  fi
+
 fi
 }
 

--- a/get_options.sh
+++ b/get_options.sh
@@ -226,10 +226,10 @@ while getopts "han:b:r:l:i:p:v:d:f:c:R:s:z:x:gkK:" OPTION ; do
        export OPT_SSHKEYS_URL="$OPTARG"
        export OPT_USE_SSHKEYS="1"
      else
-        msg="=> FAILED: cannot install ssh-keys without a source"
-        debug "$msg"
-        echo -e "${RED}$msg${NOCOL}"
-        exit 1
+      msg="=> FAILED: cannot install ssh-keys without a source"
+      debug "$msg"
+      echo -e "${RED}$msg${NOCOL}"
+      exit 1
      fi
      ;;
   esac
@@ -246,10 +246,10 @@ if [ -n "$OPT_AUTOMODE" ] && [ -z "$OPT_IMAGE" ] && [ -z "$OPT_CONFIGFILE" ] ; t
 fi
 
 if [ -n "$OPT_USE_SSHKEYS" ] && [ -z "$OPT_SSHKEYS_URL" ]; then
-        msg="=> FAILED: Should install SSH keys, but key URL not set."
-        debug "$msg"
-        echo -e "${RED}$msg${NOCOL}"
-        exit 1
+  msg="=> FAILED: Should install SSH keys, but key URL not set."
+  debug "$msg"
+  echo -e "${RED}$msg${NOCOL}"
+  exit 1
 fi
 
 # DEBUG:


### PR DESCRIPTION
right now it is only possible to download a key if you set the url via
commandline, we would also like to set it via config file. This
addresses issue #123