### PR TITLE
Force 32bit filesystem feature for ext on centos lt 70

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -2134,10 +2134,10 @@ format_partitions() {
         # then write swap information
         mkswap "$DEV" 2>&1 | debugoutput ; EXITCODE=$?
       elif [ "$FS" = "ext2" ] || [ "$FS" = "ext3" ] || [ "$FS" = "ext4" ]; then
-        if [ "$IAM" == "centos" ] && [ "$IMG_VERSION" -ge 70 ]; then
-          mkfs -t "$FS" -q "$DEV" 2>&1 | debugoutput ; EXITCODE=$?
-        else
+        if [ "$IAM" == "centos" ] && [ "$IMG_VERSION" -lt 70 ]; then
           mkfs -t "$FS" -O ^64bit -q "$DEV" 2>&1 | debugoutput ; EXITCODE=$?
+        else
+          mkfs -t "$FS" -q "$DEV" 2>&1 | debugoutput ; EXITCODE
         fi
       elif [ "$FS" = "btrfs" ]; then
         wipefs "$DEV" | debugoutput

--- a/functions.sh
+++ b/functions.sh
@@ -2134,7 +2134,11 @@ format_partitions() {
         # then write swap information
         mkswap "$DEV" 2>&1 | debugoutput ; EXITCODE=$?
       elif [ "$FS" = "ext2" ] || [ "$FS" = "ext3" ] || [ "$FS" = "ext4" ]; then
-        mkfs -t "$FS" -q "$DEV" 2>&1 | debugoutput ; EXITCODE=$?
+        if [ "$IAM" == "centos" ] && [ "$IMG_VERSION" -ge 70 ]; then
+          mkfs -t "$FS" -q "$DEV" 2>&1 | debugoutput ; EXITCODE=$?
+        else
+          mkfs -t "$FS" -O ^64bit -q "$DEV" 2>&1 | debugoutput ; EXITCODE=$?
+        fi
       elif [ "$FS" = "btrfs" ]; then
         wipefs "$DEV" | debugoutput
         mkfs -t "$FS" "$DEV" 2>&1 | debugoutput ; EXITCODE=$?


### PR DESCRIPTION
logic corrected.
fix #140 