### PR TITLE
disable metdata_csum for centos < 7

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -2137,7 +2137,7 @@ format_partitions() {
         mkswap "$DEV" 2>&1 | debugoutput ; EXITCODE=$?
       elif [ "$FS" = "ext2" ] || [ "$FS" = "ext3" ] || [ "$FS" = "ext4" ]; then
         if [ "$IAM" == "centos" ] && [ "$IMG_VERSION" -lt 70 ]; then
-          mkfs -t "$FS" -O ^64bit -q "$DEV" 2>&1 | debugoutput ; EXITCODE=$?
+          mkfs -t "$FS" -O '^64bit' -O '^metadata_csum' -q "$DEV" 2>&1 | debugoutput ; EXITCODE=$?
         else
           mkfs -t "$FS" -q "$DEV" 2>&1 | debugoutput ; EXITCODE=$?
         fi


### PR DESCRIPTION
This feature is not supported on centos 6 resulting in boot failures.
It was enabled by default somewhat recently in Arch Linux, which is used
to run installimage.

Signed-off-by: Thore Bödecker <me@foxxx0.de>