### PR TITLE
fix FORCE_GPT parsing and exporting

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -62,7 +62,6 @@ ERROREXIT="0"
 FINALIMAGEPATH=""
 
 PLESK_STD_VERSION="PLESK_12_5_30"
-FORCE_GPT=1
 SYSMFC=$(dmidecode -s system-manufacturer 2>/dev/null | head -n1)
 SYSTYPE=$(dmidecode -s system-product-name 2>/dev/null | head -n1)
 MBTYPE=$(dmidecode -s baseboard-product-name 2>/dev/null | head -n1)
@@ -609,7 +608,11 @@ if [ -n "$1" ]; then
   # special hidden configure option: GPT usage
   # if set to 1, use GPT even on disks smaller than 2TiB
   # if set to 2, always use GPT, even if the OS does not support it
-  FORCE_GPT="$(grep -m1 -e ^FORCE_GPT "$1" |awk '{print $2}')"
+  [ -z "${FORCE_GPT}" ] && FORCE_GPT=1
+  if grep -q -e '^FORCE_GPT' "$1"; then
+    FORCE_GPT="$(grep -m1 -e '^FORCE_GPT' "$1" |awk '{print $2}')"
+  fi
+  export FORCE_GPT
 
   # another special hidden configure option: force image validation
   # if set to 1: force validation


### PR DESCRIPTION
Previosly the grep command in question could also result in an empty
string if FORCE_GPT was not specified in the provided installimage
config.

This commit checks if the FORCE_GPT param was actually present in the
config before trying to overwrite it.
Additionally, it is initialized to "1" if it was an emptystring
beforehand.
You can now use your local config.sh to export a value for FORCE_GPT, as
in this case the initialization to "1" would not take place.

Furthermore the variable FORCE_GPT is now properly exported in the
correct place, so it present in the env while install.sh and
autosetup.sh are running.

Signed-off-by: Thore Bödecker <me@foxxx0.de>