### PR TITLE
reset HASROOT counter when re-reading vars

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -597,6 +597,8 @@ getdrives() {
 # read_vars "CONFIGFILE"
 read_vars(){
 if [ -n "$1" ]; then
+  # reset counter
+  HASROOT=0
   # count disks again, for setting COUNT_DRIVES correct after restarting installimage
   getdrives
 


### PR DESCRIPTION
This is required when errors in the config were detected and an editor
is launched to fix them individually.
At subsequent checks of the config the HASROOT counter variable will be
incremented indefinitly, thus breaking the == 1 check for the root
partition.

This commit resets the counter to 0 at each run of read_vars() which
fixes it.

Signed-off-by: Thore Bödecker <me@foxxx0.de>