### PR TITLE
add ability to enable/disable dwc

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 + [Requirements](#requirements)
 + [Configuration](#configuration)
 + [Usage](#usage)
+    - [Special settings](#special-settings)
 + [How does it work](#how-does-it-work)
 + [Styleguide](#styleguide)
 + [Name origin](#name-origin)
@@ -115,6 +116,21 @@ the installimage ships an example configuration file, `config-example.sh`, you'v
 ```bash
 $ installimage ...
 ```
+
+### Special settings
+
+There are some settings available within an installimage config which may be desireable for custom setups.
+With ongoing effort we try to document them here but this list is likely incomplete.
+
+#### DWC_ENABLE
+
+DWC in this context refers to the drive-write cache of modern hard disk and solid state drives.
+
+This settings currently supports the following three distinct values:
+  - 0 = disables the DWC for all drives
+  - 1 = enables the DWC for SSDs
+  - 2 = enables the DWC for all drives
+
 
 ---
 

--- a/config-example.sh
+++ b/config-example.sh
@@ -57,8 +57,9 @@ export DEFAULTFOURDRIVESWRAIDLEVEL="6"
 export DEFAULTLVM="0"
 export DEFAULTLOADER="grub"
 export DEFAULTGOVERNOR="ondemand"
-
+export FORCE_GPT=1
 export V6ONLY="0"
+declare -x -i DWC_ENABLE=1
 
 # dialog settings
 export DIATITLE="$COMPANY"


### PR DESCRIPTION
The so-called DWC (drive write cache) option is a feature supported by
most modern hard disks and solid state drives.
It allows the respective drive to cache write requests in the internal
drive-cache before flushing it to the actual persistent memory.
This implies, that a sync() is not necessarily already written to disk
and thus might cause filesystem corruption.

Depending on OS and kernel versions as well as type of hardware, this
setting varies between not supported, off and on.

On newer kernels and SSDs this is mostly enabled by default, as the DWC
is very helpful to reduce write amplification and throughput on NAND
flash drives by allowing the drive to queue requests and always write
full blocks.

The config option "DWC_ENABLE" introduced with this commit defaults to 1
in a similar manner as "FORCE_GPT".
A setting of 0 means that DWC will be forced off for all drives.
A setting of 1 means that DWC will be enabled for SSDs but not HDDs.
A setting of 2 means that DWC will be enabled for all drives.

Signed-off-by: Thore Bödecker <me@foxxx0.de>